### PR TITLE
Add plabs output command for full scenario JSON output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ Thumbs.db
 # Demo active marker files
 **/.demo_active
 .test-results/
+.claude/settings.local.json

--- a/internal/cmd/output.go
+++ b/internal/cmd/output.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/pathfinding-labs/internal/scenarios"
+	"github.com/DataDog/pathfinding-labs/internal/terraform"
+)
+
+var outputRaw bool
+
+var outputCmd = &cobra.Command{
+	Use:   "output <id>",
+	Short: "Print the full terraform output block for a deployed scenario",
+	Long: `Print the complete terraform output block for a deployed scenario as JSON.
+
+By default the output is pretty-printed. Use --raw for minified JSON suitable
+for piping to jq or other tools.
+
+Examples:
+  plabs output iam-002-to-admin
+  plabs output iam-002-to-admin --raw | jq .starting_user_access_key_id
+  plabs output iam-002-to-admin --raw | jq .admin_user_arn`,
+	Args: cobra.ExactArgs(1),
+	RunE: runOutput,
+}
+
+// outputAliasCmd is registered as a subcommand of scenarios.
+var outputAliasCmd = &cobra.Command{
+	Use:   "output <id>",
+	Short: "Print the full terraform output block for a deployed scenario",
+	Long:  outputCmd.Long,
+	Args:  cobra.ExactArgs(1),
+	RunE:  runOutput,
+}
+
+func init() {
+	outputCmd.Flags().BoolVar(&outputRaw, "raw", false, "Output minified JSON (for piping to jq)")
+	outputAliasCmd.Flags().BoolVar(&outputRaw, "raw", false, "Output minified JSON (for piping to jq)")
+}
+
+func runOutput(cmd *cobra.Command, args []string) error {
+	id := args[0]
+
+	paths, err := getWorkingPaths()
+	if err != nil {
+		return fmt.Errorf("failed to get paths: %w", err)
+	}
+
+	// Find scenario by ID — does not require it to be enabled in config
+	discovery := scenarios.NewDiscovery(paths.ScenariosPath())
+	scenario, err := discovery.FindByID(id)
+	if err != nil {
+		return fmt.Errorf("failed to find scenario: %w", err)
+	}
+	if scenario == nil {
+		fmt.Fprintf(os.Stderr, "Error: scenario %q not found\n", id)
+		fmt.Fprintf(os.Stderr, "Use 'plabs scenarios list' to see available scenarios\n")
+		os.Exit(1)
+	}
+
+	runner := terraform.NewRunner(paths.BinPath, paths.TerraformDir)
+	if !runner.IsInitialized() {
+		fmt.Fprintf(os.Stderr, "Error: terraform is not initialized\n")
+		fmt.Fprintf(os.Stderr, "Run 'plabs deploy' to deploy your scenarios\n")
+		os.Exit(1)
+	}
+
+	outputJSON, err := runner.OutputJSON()
+	if err != nil {
+		return fmt.Errorf("failed to get terraform outputs: %w", err)
+	}
+
+	outputs, err := terraform.ParseOutputs(outputJSON)
+	if err != nil {
+		return fmt.Errorf("failed to parse terraform outputs: %w", err)
+	}
+
+	outputName := getScenarioOutputName(scenario)
+	block, exists := outputs.GetScenarioOutput(outputName)
+	if !exists {
+		fmt.Fprintf(os.Stderr, "Error: output key %q not found — is the scenario deployed?\n", outputName)
+		fmt.Fprintf(os.Stderr, "Run 'plabs deploy' to deploy it\n")
+		os.Exit(1)
+	}
+	if block == nil {
+		fmt.Fprintf(os.Stderr, "Error: scenario %q is not deployed (output is null)\n", scenario.UniqueID())
+		fmt.Fprintf(os.Stderr, "Run 'plabs deploy' to deploy it\n")
+		os.Exit(1)
+	}
+
+	var data []byte
+	if outputRaw {
+		data, err = json.Marshal(block)
+	} else {
+		data, err = json.MarshalIndent(block, "", "  ")
+	}
+	if err != nil {
+		return fmt.Errorf("failed to marshal output: %w", err)
+	}
+
+	fmt.Println(string(data))
+	return nil
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -58,6 +58,7 @@ func init() {
 	rootCmd.AddCommand(demoCmd)
 	rootCmd.AddCommand(cleanupCmd)
 	rootCmd.AddCommand(credentialsCmd)
+	rootCmd.AddCommand(outputCmd)
 	rootCmd.AddCommand(versionCmd)
 }
 

--- a/internal/cmd/scenarios.go
+++ b/internal/cmd/scenarios.go
@@ -80,6 +80,7 @@ func init() {
 	scenariosCmd.AddCommand(scenariosListCmd)
 	scenariosCmd.AddCommand(showCmd)
 	scenariosCmd.AddCommand(credentialsAliasCmd)
+	scenariosCmd.AddCommand(outputAliasCmd)
 
 	// Add enable, disable, demo, cleanup as subcommands of scenarios
 	// (they also exist at top level as aliases)


### PR DESCRIPTION
## Why

External tools (benchmark harnesses, verifiers) need more than just AWS credentials from a deployed scenario — they also need metadata like `admin_user_arn`, `attack_path`, and other fields from the terraform output block.

The existing `plabs credentials <id>` command only surfaces three normalized fields (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`). Getting the full block currently requires calling `terraform output -json` directly, which:
- Couples the caller to the terraform working directory layout
- Requires knowing the internal output key format (e.g. `single_account_privesc_one_hop_to_admin_iam_002_iam_createaccesskey`)
- Bypasses the scenario ID resolution logic already built into `plabs`

## What

Adds `plabs output <scenario-id>` (also available as `plabs scenarios output <scenario-id>`) that:

- Resolves the scenario ID to its terraform output key using the same discovery logic as the rest of the CLI
- Calls `terraform output -json` via the existing `runner.OutputJSON()` path
- Prints the full raw output block as pretty-printed JSON
- Supports `--raw` for minified JSON suitable for piping to `jq`
- Exits non-zero if the scenario isn't found or isn't deployed

## Usage

```bash
# Pretty-print the full output block
plabs output iam-002-to-admin

# Pipe specific fields to jq
plabs output iam-002-to-admin --raw | jq .admin_user_arn
plabs output iam-002-to-admin --raw | jq .starting_user_access_key_id

# Also available as a scenarios subcommand
plabs scenarios output iam-002-to-admin
```

## Test plan

- [x] `make build && ./build/plabs output iam-002-to-admin` prints full JSON block for a deployed scenario
- [ ] `./build/plabs output iam-002-to-admin --raw | jq .admin_user_arn` returns the ARN
- [x] `./build/plabs output does-not-exist` exits 1 with a helpful error
- [ ] `./build/plabs output iam-002-to-admin` on an undeployed scenario exits 1 with "not deployed"
- [x] `./build/plabs scenarios output iam-002-to-admin` works as alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)