### PR TITLE
Only run CI on Go-related changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [main, plabs]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/ci.yml'
 
 jobs:
   build:


### PR DESCRIPTION
Scope the CI workflow's push/pull_request triggers to *.go, go.mod, go.sum, and the workflow file itself, so README/metadata/scenario-only PRs no longer build and lint the plabs binary for no reason.
